### PR TITLE
fix: PickupSpell updated to use C_Spell.PickupSpell if available

### DIFF
--- a/BindPad/BindPad.lua
+++ b/BindPad/BindPad.lua
@@ -80,6 +80,7 @@ local GetSpecialization = isRetail and GetSpecialization or GetActiveTalentGroup
 local GetItemInfo = C_Item.GetItemInfo and C_Item.GetItemInfo or GetItemInfo
 local GetItemSpell = C_Item.GetItemSpell and C_Item.GetItemSpell or GetItemSpell
 local PickupItem = C_Item.PickupItem and C_Item.PickupItem or PickupItem
+local PickupSpell = C_Spell.PickupSpell and C_Spell.PickupSpell or PickupSpell
 local GetSpellBookItemName = C_SpellBook.GetSpellBookItemName and C_SpellBook.GetSpellBookItemName or GetSpellBookItemName
 local GetContainerItemID = C_Item.GetContainerItemID and C_Item.GetContainerItemID or GetContainerItemID
 local GetNumEquipmentSets = C_EquipmentSet.GetNumEquipmentSets and C_EquipmentSet.GetNumEquipmentSets or GetNumEquipmentSets


### PR DESCRIPTION
New to wow addons, so I apologize if this isn't quite right but I figured I'd take a stab at a bugfix. Please let me know if I can do anything different in the future to make this process easier! 

**Issue:**
Moving a spell from one slot to another in the retail bindpad window doesn't work and throws the error in the screenshot below. 

**Cause:**
TWW api updates to PickupSpell

**Fix:**
I tried to copy what the code was already doing for similar spells that moved but didn't have breaking changes to their return values. The new function appears to be [`C_Spell.PickupSpell`](https://warcraft.wiki.gg/wiki/API_C_Spell.PickupSpell)

![image](https://github.com/user-attachments/assets/f5e5688d-6772-4f18-b3aa-38739d71e5d4)
