### PR TITLE
fix GetSpellBookItemName missing parameters

### DIFF
--- a/BindPad/BindPad.lua
+++ b/BindPad/BindPad.lua
@@ -1993,7 +1993,7 @@ function BindPadCore.GameTooltipSetSpellByID(self, spellID)
 end
 
 function BindPadCore.GameTooltipSetSpellBookItem(self, slot, bookType)
-    BindPadCore.InsertBindingTooltip(concat("SPELL ", C_SpellBook.GetSpellBookItemName and C_SpellBook.GetSpellBookItemName or GetSpellBookItemName(slot, bookType)))
+    BindPadCore.InsertBindingTooltip(concat("SPELL ", GetSpellBookItemName(slot, bookType)))
 end
 
 function BindPadCore.GameTooltipSetAction(self, slot)


### PR DESCRIPTION
`BindPadCore.GameTooltipSetSpellBookItem` was trying to concat with missing params for `C_SpellBook.GetSpellBookItemName`.

It was placed here presumably for a flavor check, but since this check is unnecessary here anyway (because it's defined [on line 84](https://github.com/Stanzilla/BindPad/blob/master/BindPad/BindPad.lua#L84)) a more convenient fix is to just remove it all together and use the defined `GetSpellBookItemName`

Alternatively, adding the params if you want to keep the check in-place will work too.

Fixes #22 